### PR TITLE
#121 - Fixed number conversion in change codec priority.

### DIFF
--- a/ios/RTCPjSip/PjSipEndpoint.m
+++ b/ios/RTCPjSip/PjSipEndpoint.m
@@ -280,7 +280,8 @@
     for (NSString * key in codecSettings) {
         pj_str_t codec_id = pj_str((char *) [key UTF8String]);
         NSNumber * priority = codecSettings[key];
-        pjsua_codec_set_priority(&codec_id, priority);
+        pj_uint8_t convertedPriority = [priority integerValue];
+        pjsua_codec_set_priority(&codec_id, convertedPriority);
     }
     
 }


### PR DESCRIPTION
Referencing issue #121. 

Converts NSNumber to the correct pj_uint_8 which is required by pjsua_codec_set_priority. 
