### PR TITLE
Fixed memory issue in calls with multiple headers.

### DIFF
--- a/ios/RTCPjSip/PjSipUtil.h
+++ b/ios/RTCPjSip/PjSipUtil.h
@@ -13,6 +13,6 @@
 +(NSString *) mediaTypeToString: (pjmedia_type) type;
 
 +(void) fillCallSettings: (pjsua_call_setting*) callSettings dict:(NSDictionary*) dict;
-+(void) fillMsgData: (pjsua_msg_data*) msgData dict:(NSDictionary*) dict;
++(void) fillMsgData: (pjsua_msg_data*) msgData dict:(NSDictionary*) dict pool:(pj_pool_t*) pool;
 
 @end


### PR DESCRIPTION
Fixes #114 by replacing header malloc with `pj_pool_t` which then releases pool from memory after call is made. 