### PR TITLE
Call the correct duration method in getFormattedTotalDuration

### DIFF
--- a/src/Call.js
+++ b/src/Call.js
@@ -122,7 +122,7 @@ export default class Call {
      * @returns {string}
      */
     getFormattedTotalDuration() {
-        return this._formatTime(this.getDuration());
+        return this._formatTime(this.getTotalDuration());
     };
 
     /**
@@ -343,7 +343,7 @@ export default class Call {
      * - PJSIP_SC_NOT_ACCEPTABLE_ANYWHERE / 606
      * - PJSIP_SC_TSX_TIMEOUT / PJSIP_SC_REQUEST_TIMEOUT
      * - PJSIP_SC_TSX_TRANSPORT_ERROR / PJSIP_SC_SERVICE_UNAVAILABLE
-     * 
+     *
      * @returns {string}
      */
     getLastStatusCode() {


### PR DESCRIPTION
Fixes #127 