### PR TITLE
Add unregisterReceiver for android

### DIFF
--- a/android/src/main/java/com/carusto/ReactNativePjSip/PjSipService.java
+++ b/android/src/main/java/com/carusto/ReactNativePjSip/PjSipService.java
@@ -267,6 +267,8 @@ public class PjSipService extends Service {
             Log.w(TAG, "Failed to destroy PjSip library", e);
         }
 
+        unregisterReceiver(mPhoneStateChangedReceiver);
+
         super.onDestroy();
     }
 


### PR DESCRIPTION
Missing unregisterReceiver causes memory leak on pjsip destroy