### PR TITLE
Change download path in libs.sh

### DIFF
--- a/libs.sh
+++ b/libs.sh
@@ -4,7 +4,7 @@ set -e
 VERSION="v2.8.0"
 URL="https://github.com/datso/react-native-pjsip-builder/releases/download/${VERSION}/release.tar.gz"
 LOCK=".libs.lock"
-DEST=".libs.tar.gz"
+DEST="release.tar.gz"
 DOWNLOAD=true
 
 if ! type "curl" > /dev/null; then


### PR DESCRIPTION
With the DEST set to ".libs.tar.gz" the untar would sometimes fail for us. Using the regular filename of the download works flawlessly each time we tried to use it.