### PR TITLE
Fix Module PjSip ios

### DIFF
--- a/ios/RTCPjSip/PjSipModule.m
+++ b/ios/RTCPjSip/PjSipModule.m
@@ -24,6 +24,11 @@
     return self;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_METHOD(start: (NSDictionary *) config callback: (RCTResponseSenderBlock) callback) {
     [PjSipEndpoint instance].bridge = self.bridge;
 


### PR DESCRIPTION
Fix warning on IOS

> Module PjSip Module requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.