### PR TITLE
fix: Prevent app crash and disable video count

### DIFF
--- a/android/src/main/java/com/carusto/ReactNativePjSip/PjSipService.java
+++ b/android/src/main/java/com/carusto/ReactNativePjSip/PjSipService.java
@@ -262,6 +262,7 @@ public class PjSipService extends Service {
         try {
             if (mEndpoint != null) {
                 mEndpoint.libDestroy();
+                mEndpoint.delete();
             }
         } catch (Exception e) {
             Log.w(TAG, "Failed to destroy PjSip library", e);

--- a/ios/RTCPjSip/PjSipCall.m
+++ b/ios/RTCPjSip/PjSipCall.m
@@ -48,7 +48,7 @@
     
     // TODO: Audio/Video count configuration!
     callOpt.aud_cnt = 1;
-    callOpt.vid_cnt = 1;
+    callOpt.vid_cnt = 0;// Assac - changed from 1
     
     pjsua_call_answer2(self.id, &callOpt, 200, NULL, &msgData);
 }
@@ -129,6 +129,7 @@
 
     pjsua_call_setting callOpt;
     pjsua_call_setting_default(&callOpt);
+    callOpt.vid_cnt = 0;// Assac - added
     pjsua_call_answer2(self.id, &callOpt, PJSIP_SC_MOVED_TEMPORARILY, NULL, &msgData);
 }
 
@@ -195,10 +196,10 @@
         
         @"remoteOfferer": @(info.rem_offerer),
         @"remoteAudioCount": @(info.rem_aud_cnt),
-        @"remoteVideoCount": @(info.rem_vid_cnt),
+        @"remoteVideoCount": @(0),// Assac - changed from @(info.rem_vid_cnt)
         
         @"audioCount": @(info.setting.aud_cnt),
-        @"videoCount": @(info.setting.vid_cnt),
+        @"videoCount": @(0),// Assac - changed from @(info.setting.vid_cnt)
         
         @"media": [self mediaInfoToJsonArray:info.media count:info.media_cnt],
         @"provisionalMedia": [self mediaInfoToJsonArray:info.prov_media count:info.prov_media_cnt]

--- a/ios/RTCPjSip/PjSipEndpoint.m
+++ b/ios/RTCPjSip/PjSipEndpoint.m
@@ -216,6 +216,7 @@
 -(PjSipCall *) makeCall:(PjSipAccount *) account destination:(NSString *)destination callSettings: (NSDictionary *)callSettingsDict msgData: (NSDictionary *)msgDataDict {
     pjsua_call_setting callSettings;
     [PjSipUtil fillCallSettings:&callSettings dict:callSettingsDict];
+    callSettings.vid_cnt = 0;// Assac - added
     
     pj_caching_pool cp;
     pj_pool_t *pool;
@@ -308,7 +309,9 @@
      * we can simply ignore them.
     */
     for (int i = pjsua_vid_dev_count() - 1; i >= 0; i--) {
-        pjsua_vid_dev_set_setting(i, PJMEDIA_VID_DEV_CAP_ORIENTATION, &orient, PJ_TRUE);
+        // Assac - start
+        //pjsua_vid_dev_set_setting(i, PJMEDIA_VID_DEV_CAP_ORIENTATION, &orient, PJ_TRUE);
+        // Assac - end
     }
 }
 

--- a/ios/RTCPjSip/PjSipUtil.m
+++ b/ios/RTCPjSip/PjSipUtil.m
@@ -221,7 +221,7 @@
             callSettings->aud_cnt = [dict[@"audioCount"] intValue];
         }
         if (dict[@"videoCount"] != nil) {
-            callSettings->vid_cnt = [dict[@"videoCount"] intValue];
+            callSettings->vid_cnt = 0;// Assac - changed from [dict[@"videoCount"] intValue]
         }
         if (dict[@"flag"] != nil) {
             callSettings->flag = [dict[@"flag"] intValue];


### PR DESCRIPTION
This PR will prevent the android build from crashing when Pjsip service is not killed properly while in background mode on Android (8 and above). 
Also we have disabled video count to 0.