### PR TITLE
Set PJ_AUTOCONF on react-native-pjsip.podspec

### DIFF
--- a/ios/RTCPjSip.xcodeproj/project.pbxproj
+++ b/ios/RTCPjSip.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
@@ -275,6 +276,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
+				USE_HEADERMAP = NO;
 			};
 			name = Release;
 		};
@@ -288,6 +290,7 @@
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
+					"PJ_AUTOCONF=1",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
@@ -313,6 +316,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
+				GCC_PREPROCESSOR_DEFINITIONS = "PJ_AUTOCONF=1";
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
 					"\"$(SRCROOT)/VialerPJSIP/Headers\"",

--- a/ios/RTCPjSip.xcodeproj/project.pbxproj
+++ b/ios/RTCPjSip.xcodeproj/project.pbxproj
@@ -288,7 +288,6 @@
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
-					PJ_AUTOCONF,
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
@@ -314,7 +313,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				GCC_PREPROCESSOR_DEFINITIONS = PJ_AUTOCONF;
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../react-native/React/**",
 					"\"$(SRCROOT)/VialerPJSIP/Headers\"",

--- a/react-native-pjsip.podspec
+++ b/react-native-pjsip.podspec
@@ -17,4 +17,8 @@ Pod::Spec.new do |s|
 
   s.dependency 'React'
   s.vendored_frameworks = 'ios/VialerPJSIP.framework'
+  s.xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS' => 'PJ_AUTOCONF=1',
+    'USE_HEADERMAP' => 'NO',
+  }
 end


### PR DESCRIPTION
I got the following errors at building.

```
Compile PjSipVideoViewManager.m
[project_dir]/ios/VialerPJSIP.framework/Headers/pj/config.h:303:5: "Please specify target machine."
[project_dir]/ios/VialerPJSIP.framework/Headers/pj/config.h:1297:4: "PJ_HAS_PENTIUM is not defined!"
[project_dir]/ios/VialerPJSIP.framework/Headers/pj/config.h:1301:4: "PJ_IS_LITTLE_ENDIAN is not defined!"
[project_dir]/ios/VialerPJSIP.framework/Headers/pj/config.h:1305:4: "PJ_IS_BIG_ENDIAN is not defined!"
```

To avoid them, I set PJ_AUTOCONF on react-native-pjsip.podspec.
Thanks.

Environments:
- MacOS 10.15.7
- Xcode 12.0.1
- iOS 13.5.1 (iPhone X)
- react-native 0.63.2

References:
- https://github.com/florindumitru/react-native-sip/issues/6#issuecomment-605302549
- https://github.com/FastPBX/react-native-sip/blob/14cbbf082bc484c8ed8651b110adf475acb2f7bf/react-native-sip.podspec#L19-L22