### PR TITLE
renamed interface to prevent name conflict

### DIFF
--- a/ios/RTCPjSip/PjSipVideoViewManager.m
+++ b/ios/RTCPjSip/PjSipVideoViewManager.m
@@ -7,13 +7,13 @@
  * Implements an equivalent of {@code HTMLVideoElement} i.e. Web's video
  * element.
  */
-@interface RTCVideoView : RCTView
+@interface PjSipVideoView : RCTView
 
 // @property pjsua_vid_win_id vidWinId;
 
 @end
 
-@implementation RTCVideoView {
+@implementation PjSipVideoView {
     
 }
 
@@ -68,14 +68,14 @@
 RCT_EXPORT_MODULE()
 
 -(UIView *)view {
-    return [[RTCVideoView alloc] init];
+    return [[PjSipVideoView alloc] init];
 }
 
 - (dispatch_queue_t)methodQueue {
   return dispatch_get_main_queue();
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(windowId, NSNumber, RTCVideoView) {
+RCT_CUSTOM_VIEW_PROPERTY(windowId, NSNumber, PjSipVideoView) {
     
 //    NSLog(@"RCT_CUSTOM_VIEW_PROPERTY");
 //    


### PR DESCRIPTION
Renamed interface to prevent Xcode buildtime "Duplicate symbols for architecture x86_64" error due to name conflict with react-native-webrtc library:
https://github.com/react-native-webrtc/react-native-webrtc/blob/master/ios/RCTWebRTC/RTCVideoViewManager.m#L55